### PR TITLE
Tests: Logging changes between node 14 and 16

### DIFF
--- a/integration/simple_npm_app_test.go
+++ b/integration/simple_npm_app_test.go
@@ -72,14 +72,14 @@ func testSimpleNPMApp(t *testing.T, context spec.G, it spec.S) {
 				"    Executing scripts",
 				"      Running 'npm run-script test_script_1'",
 				"        ",
-				MatchRegexp(`        > simple_npm_app@\d+\.\d+\.\d+ test_script_1 \/workspace`),
+				MatchRegexp(`        > simple_npm_app@\d+\.\d+\.\d+ test_script_1`),
 				"        > echo \"some commands\"",
 				"        ",
 				"        some commands",
 				"        ",
 				"      Running 'npm run-script test_script_2'",
 				"        ",
-				MatchRegexp(`        > simple_npm_app@\d+\.\d+\.\d+ test_script_2 \/workspace`),
+				MatchRegexp(`        > simple_npm_app@\d+\.\d+\.\d+ test_script_2`),
 				"        > touch dummyfile.txt",
 			))
 			Expect(logs).To(ContainLines(MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))

--- a/integration/vue_npm_app_test.go
+++ b/integration/vue_npm_app_test.go
@@ -74,7 +74,7 @@ func testVueNpmApp(t *testing.T, context spec.G, it spec.S) {
 				"    Executing scripts",
 				"      Running 'npm run-script build'",
 				"        ",
-				MatchRegexp(`        > vue_app@\d+\.\d+\.\d+ build \/workspace`),
+				MatchRegexp(`        > vue_app@\d+\.\d+\.\d+ build`),
 				"        > vue-cli-service build",
 			))
 			Expect(logs).To(ContainLines(


### PR DESCRIPTION
since 16 is the default in the latest node-engine buildpack.

