### PR TITLE
Make node-run-script compatible with wildcard stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.7"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/node-run-script"
@@ -14,4 +14,4 @@ api = "0.6"
   pre-package = "./scripts/build.sh"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
+  id = "*"


### PR DESCRIPTION
This is following https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md#stack-choice