### PR TITLE
Allows buildpack to be deactivated by setting BP_NODE_RUN_SCRIPTS=""

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -68,7 +68,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		loggerBuffer = bytes.NewBuffer(nil)
 		logger = scribe.NewLogger(loggerBuffer)
 
-		build = noderunscript.Build(npmExec, yarnExec, clock, logger, noderunscript.Environment{})
+		build = noderunscript.Build(npmExec, yarnExec, clock, logger, noderunscript.Environment{
+			NodeRunScripts: "build",
+		})
 	})
 
 	it.After(func() {
@@ -174,6 +176,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(fs.Move(filepath.Join(workingDir, "package.json"), filepath.Join(workingDir, customPath, "package.json"))).To(Succeed())
 
 			build = noderunscript.Build(npmExec, yarnExec, clock, logger, noderunscript.Environment{
+				NodeRunScripts:  "build",
 				NodeProjectPath: customPath,
 			})
 		})

--- a/detect.go
+++ b/detect.go
@@ -12,6 +12,10 @@ type BuildPlanMetadata struct {
 
 func Detect(env Environment) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
+		if env.NodeRunScripts == "" {
+			return packit.DetectResult{}, packit.Fail.WithMessage(`script running has been deactivated: BP_NODE_RUN_SCRIPTS=""`)
+		}
+
 		_, packageManager, err := ScriptsToRun(filepath.Join(context.WorkingDir, env.NodeProjectPath), env.NodeRunScripts)
 		if err != nil {
 			return packit.DetectResult{}, err

--- a/detect_test.go
+++ b/detect_test.go
@@ -33,7 +33,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			}
 		}`), 0600)).To(Succeed())
 
-		detect = noderunscript.Detect(noderunscript.Environment{})
+		detect = noderunscript.Detect(noderunscript.Environment{
+			NodeRunScripts: "build",
+		})
 	})
 
 	it.After(func() {
@@ -104,6 +106,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				WorkingDir: workingDir,
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	context("when env var $BP_NODE_RUN_SCRIPTS is empty", func() {
+		it.Before(func() {
+			detect = noderunscript.Detect(noderunscript.Environment{NodeRunScripts: ""})
+		})
+
+		it("fails detection", func() {
+			_, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).To(MatchError(packit.Fail.WithMessage(`script running has been deactivated: BP_NODE_RUN_SCRIPTS=""`)))
 		})
 	})
 

--- a/environment.go
+++ b/environment.go
@@ -1,7 +1,33 @@
 package noderunscript
 
+import "strings"
+
 type Environment struct {
 	LogLevel        string
 	NodeProjectPath string
 	NodeRunScripts  string
+}
+
+func LoadEnvironment(variables []string) Environment {
+	environment := Environment{
+		LogLevel:        "INFO",
+		NodeProjectPath: ".",
+		NodeRunScripts:  "build",
+	}
+
+	for _, variable := range variables {
+		key, value, found := strings.Cut(variable, "=")
+		if found {
+			switch key {
+			case "LOG_LEVEL":
+				environment.LogLevel = value
+			case "BP_NODE_PROJECT_PATH":
+				environment.NodeProjectPath = value
+			case "BP_NODE_RUN_SCRIPTS":
+				environment.NodeRunScripts = value
+			}
+		}
+	}
+
+	return environment
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -1,0 +1,52 @@
+package noderunscript_test
+
+import (
+	"testing"
+
+	noderunscript "github.com/paketo-buildpacks/node-run-script"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testEnvironment(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	it("returns a parsed environment", func() {
+		environment := noderunscript.LoadEnvironment([]string{
+			"BP_NODE_PROJECT_PATH=some-node-project-path-value",
+			"BP_NODE_RUN_SCRIPTS=some-node-run-scripts-value",
+			"LOG_LEVEL=some-log-level-value",
+		})
+
+		Expect(environment).To(Equal(noderunscript.Environment{
+			LogLevel:        "some-log-level-value",
+			NodeProjectPath: "some-node-project-path-value",
+			NodeRunScripts:  "some-node-run-scripts-value",
+		}))
+	})
+
+	context("when no values are set", func() {
+		it("uses the defaults", func() {
+			environment := noderunscript.LoadEnvironment([]string{})
+
+			Expect(environment).To(Equal(noderunscript.Environment{
+				LogLevel:        "INFO",
+				NodeProjectPath: ".",
+				NodeRunScripts:  "build",
+			}))
+		})
+	})
+
+	context("when explicit empty values are given", func() {
+		it("uses the empty values", func() {
+			environment := noderunscript.LoadEnvironment([]string{
+				"BP_NODE_PROJECT_PATH=",
+				"BP_NODE_RUN_SCRIPTS=",
+				"LOG_LEVEL=",
+			})
+
+			Expect(environment).To(Equal(noderunscript.Environment{}))
+		})
+	})
+}

--- a/init_test.go
+++ b/init_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestUnitNodeRunScript(t *testing.T) {
-	suite := spec.New("node-run-script", spec.Report(report.Terminal{}), spec.Sequential())
+	suite := spec.New("node-run-script", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("Environment", testEnvironment)
 	suite("Scripts", testScripts)
 	suite.Run(t)
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -51,6 +51,7 @@ var settings struct {
 
 func TestIntegration(t *testing.T) {
 	Expect := NewWithT(t).Expect
+	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	file, err := os.Open("../integration.json")
 	Expect(err).NotTo(HaveOccurred())
@@ -90,13 +91,14 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.YarnInstall)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(10 * time.Second)
+	pack := occam.NewPack()
+	docker := occam.NewDocker()
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
-	suite("SimpleYarnApp", testSimpleYarnApp)
-	suite("SimpleNPMApp", testSimpleNPMApp)
-	suite("ProjectPathApp", testProjectPathApp)
-	suite("VueNPMApp", testVueNPMApp)
-	suite("VueYarnApp", testVueYarnApp)
+	suite("SimpleYarnApp", testSimpleYarnApp(pack, docker))
+	suite("SimpleNPMApp", testSimpleNPMApp(pack, docker))
+	suite("ProjectPathApp", testProjectPathApp(pack, docker))
+	suite("VueNPMApp", testVueNPMApp(pack, docker))
+	suite("VueYarnApp", testVueYarnApp(pack, docker))
 	suite.Run(t)
 }

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -13,88 +13,82 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testProjectPathApp(t *testing.T, context spec.G, it spec.S) {
-	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-
-		pack   occam.Pack
-		docker occam.Docker
-	)
-
-	it.Before(func() {
-		pack = occam.NewPack()
-		docker = occam.NewDocker()
-	})
-
-	context("when building a simple yarn app inside a nested directory", func() {
+func testProjectPathApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
 		var (
-			image     occam.Image
-			container occam.Container
-
-			name   string
-			source string
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
 		)
 
-		it.Before(func() {
-			var err error
-			name, err = occam.RandomName()
-			Expect(err).NotTo(HaveOccurred())
-		})
+		context("when building a simple yarn app inside a nested directory", func() {
+			var (
+				image     occam.Image
+				container occam.Container
 
-		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			Expect(os.RemoveAll(source)).To(Succeed())
-		})
+				name   string
+				source string
+			)
 
-		it("builds an OCI image for the app", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "project_path_app"))
-			Expect(err).NotTo(HaveOccurred())
-
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.Yarn.Online,
-					settings.Buildpacks.YarnInstall.Online,
-					settings.Buildpacks.NodeRunScript.Online,
-				).
-				WithEnv(map[string]string{
-					"BP_NODE_RUN_SCRIPTS":  "test_script_1,test_script_2",
-					"BP_NODE_PROJECT_PATH": "nested_yarn_app"}).
-				WithPullPolicy("never").
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
-
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'yarn run test_script_1'",
-				MatchRegexp(`      yarn run v\d+\.\d+\.\d+$`),
-				"      $ echo \"some commands\"",
-				"      some commands",
-				MatchRegexp(`    Done in \d+\.\d+s\.`),
-				"",
-				"    Running 'yarn run test_script_2'",
-				MatchRegexp(`      yarn run v\d+\.\d+\.\d+$`),
-				"      $ touch dummyfile.txt",
-				MatchRegexp(`    Done in \d+\.\d+s\.`),
-			))
-			Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
-
-			container, err = docker.Container.Run.
-				WithCommand("ls -alR /workspace/").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
+			it.Before(func() {
+				var err error
+				name, err = occam.RandomName()
 				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("dummyfile.txt"))
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+				Expect(os.RemoveAll(source)).To(Succeed())
+			})
+
+			it("builds an OCI image for the app", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "project_path_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.Yarn.Online,
+						settings.Buildpacks.YarnInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithEnv(map[string]string{
+						"BP_NODE_RUN_SCRIPTS":  "test_script_1,test_script_2",
+						"BP_NODE_PROJECT_PATH": "nested_yarn_app"}).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Executing build process",
+					"    Running 'yarn run test_script_1'",
+					MatchRegexp(`      yarn run v\d+\.\d+\.\d+$`),
+					"      $ echo \"some commands\"",
+					"      some commands",
+					MatchRegexp(`    Done in \d+\.\d+s\.`),
+					"",
+					"    Running 'yarn run test_script_2'",
+					MatchRegexp(`      yarn run v\d+\.\d+\.\d+$`),
+					"      $ touch dummyfile.txt",
+					MatchRegexp(`    Done in \d+\.\d+s\.`),
+				))
+				Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
+
+				container, err = docker.Container.Run.
+					WithCommand("ls -alR /workspace/").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring("dummyfile.txt"))
+			})
 		})
-	})
+	}
 }

--- a/integration/simple_npm_app_test.go
+++ b/integration/simple_npm_app_test.go
@@ -13,24 +13,11 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testSimpleNPMApp(t *testing.T, context spec.G, it spec.S) {
-	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-
-		pack   occam.Pack
-		docker occam.Docker
-	)
-
-	it.Before(func() {
-		pack = occam.NewPack()
-		docker = occam.NewDocker()
-	})
-
-	context("when building a simple npm app", func() {
+func testSimpleNPMApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
 		var (
-			image     occam.Image
-			container occam.Container
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
 
 			name   string
 			source string
@@ -40,61 +27,89 @@ func testSimpleNPMApp(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "simple_npm_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		it("builds an OCI image for a simple npm app", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "simple_npm_app"))
-			Expect(err).NotTo(HaveOccurred())
+		context("when building a simple npm app", func() {
+			var (
+				image     occam.Image
+				container occam.Container
+			)
 
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.NPMInstall.Online,
-					settings.Buildpacks.NodeRunScript.Online,
-				).
-				WithEnv(map[string]string{"BP_NODE_RUN_SCRIPTS": "test_script_1,test_script_2"}).
-				WithPullPolicy("never").
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			})
 
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'npm run test_script_1'",
-				"      ",
-				MatchRegexp(`      > simple_npm_app@\d+\.\d+\.\d+ test_script_1`),
-				"      > echo \"some commands\"",
-				"      ",
-				"      some commands",
-				"",
-				"    Running 'npm run test_script_2'",
-				"      ",
-				MatchRegexp(`      > simple_npm_app@\d+\.\d+\.\d+ test_script_2`),
-				"      > touch dummyfile.txt",
-				"      ",
-				"",
-				MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-			))
+			it("builds an OCI image for a simple npm app", func() {
+				var logs fmt.Stringer
+				var err error
+				image, logs, err = pack.Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.NPMInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithEnv(map[string]string{"BP_NODE_RUN_SCRIPTS": "test_script_1,test_script_2"}).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
 
-			container, err = docker.Container.Run.
-				WithCommand("ls -al /workspace/").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Executing build process",
+					"    Running 'npm run test_script_1'",
+					"      ",
+					MatchRegexp(`      > simple_npm_app@\d+\.\d+\.\d+ test_script_1`),
+					"      > echo \"some commands\"",
+					"      ",
+					"      some commands",
+					"",
+					"    Running 'npm run test_script_2'",
+					"      ",
+					MatchRegexp(`      > simple_npm_app@\d+\.\d+\.\d+ test_script_2`),
+					"      > touch dummyfile.txt",
+					"      ",
+					"",
+					MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+				))
 
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
+				container, err = docker.Container.Run.
+					WithCommand("ls -al /workspace/").
+					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("dummyfile.txt"))
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring("dummyfile.txt"))
+			})
 		})
-	})
+
+		context("when BP_NODE_RUN_SCRIPTS is explicitly deactivated", func() {
+			it("fails detection", func() {
+				_, logs, err := pack.WithVerbose().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.NPMInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithEnv(map[string]string{"BP_NODE_RUN_SCRIPTS": ""}).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).To(HaveOccurred())
+				Expect(logs).To(ContainLines(
+					`script running has been deactivated: BP_NODE_RUN_SCRIPTS=""`,
+				))
+			})
+		})
+	}
 }

--- a/integration/simple_yarn_app_test.go
+++ b/integration/simple_yarn_app_test.go
@@ -13,87 +13,81 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testSimpleYarnApp(t *testing.T, context spec.G, it spec.S) {
-	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-
-		pack   occam.Pack
-		docker occam.Docker
-	)
-
-	it.Before(func() {
-		pack = occam.NewPack()
-		docker = occam.NewDocker()
-	})
-
-	context("when building a simple yarn app", func() {
+func testSimpleYarnApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
 		var (
-			image     occam.Image
-			container occam.Container
-
-			name   string
-			source string
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
 		)
 
-		it.Before(func() {
-			var err error
-			name, err = occam.RandomName()
-			Expect(err).NotTo(HaveOccurred())
-		})
+		context("when building a simple yarn app", func() {
+			var (
+				image     occam.Image
+				container occam.Container
 
-		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			Expect(os.RemoveAll(source)).To(Succeed())
-		})
+				name   string
+				source string
+			)
 
-		it("builds an OCI image for a simple yarn app", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "simple_yarn_app"))
-			Expect(err).NotTo(HaveOccurred())
-
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.Yarn.Online,
-					settings.Buildpacks.YarnInstall.Online,
-					settings.Buildpacks.NodeRunScript.Online,
-				).
-				WithEnv(map[string]string{"BP_NODE_RUN_SCRIPTS": "test_script_1,test_script_2"}).
-				WithPullPolicy("never").
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
-
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'yarn run test_script_1'",
-				MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
-				"      $ echo \"some commands\"",
-				"      some commands",
-				MatchRegexp(`    Done in \d+\.\d+s\.`),
-				"",
-				"    Running 'yarn run test_script_2'",
-				MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
-				"      $ touch dummyfile.txt",
-				MatchRegexp(`    Done in \d+\.\d+s\.`),
-				"",
-				MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-			))
-
-			container, err = docker.Container.Run.
-				WithCommand("ls -al /workspace/").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
+			it.Before(func() {
+				var err error
+				name, err = occam.RandomName()
 				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("dummyfile.txt"))
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+				Expect(os.RemoveAll(source)).To(Succeed())
+			})
+
+			it("builds an OCI image for a simple yarn app", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "simple_yarn_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.Yarn.Online,
+						settings.Buildpacks.YarnInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithEnv(map[string]string{"BP_NODE_RUN_SCRIPTS": "test_script_1,test_script_2"}).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Executing build process",
+					"    Running 'yarn run test_script_1'",
+					MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
+					"      $ echo \"some commands\"",
+					"      some commands",
+					MatchRegexp(`    Done in \d+\.\d+s\.`),
+					"",
+					"    Running 'yarn run test_script_2'",
+					MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
+					"      $ touch dummyfile.txt",
+					MatchRegexp(`    Done in \d+\.\d+s\.`),
+					"",
+					MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+				))
+
+				container, err = docker.Container.Run.
+					WithCommand("ls -al /workspace/").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring("dummyfile.txt"))
+			})
 		})
-	})
+	}
 }

--- a/integration/vue_npm_app_test.go
+++ b/integration/vue_npm_app_test.go
@@ -13,81 +13,75 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testVueNPMApp(t *testing.T, context spec.G, it spec.S) {
-	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-
-		pack   occam.Pack
-		docker occam.Docker
-	)
-
-	it.Before(func() {
-		pack = occam.NewPack()
-		docker = occam.NewDocker()
-	})
-
-	context("when building a Vue npm app", func() {
+func testVueNPMApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
 		var (
-			image     occam.Image
-			container occam.Container
-
-			name   string
-			source string
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
 		)
 
-		it.Before(func() {
-			var err error
-			name, err = occam.RandomName()
-			Expect(err).NotTo(HaveOccurred())
-		})
+		context("when building a Vue npm app", func() {
+			var (
+				image     occam.Image
+				container occam.Container
 
-		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			Expect(os.RemoveAll(source)).To(Succeed())
-		})
+				name   string
+				source string
+			)
 
-		it("builds an OCI image for a Vue npm app", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "vue_npm_app"))
-			Expect(err).NotTo(HaveOccurred())
-
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.NPMInstall.Online,
-					settings.Buildpacks.NodeRunScript.Online,
-				).
-				WithPullPolicy("never").
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
-
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'npm run build'",
-				"      ",
-				MatchRegexp(`      > vue_app@\d+\.\d+\.\d+ build`),
-				"      > vue-cli-service build",
-			))
-			Expect(logs).To(ContainLines(
-				"       DONE  Build complete. The dist directory is ready to be deployed.",
-			))
-			Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
-
-			container, err = docker.Container.Run.
-				WithCommand("ls -al /workspace/dist/").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
+			it.Before(func() {
+				var err error
+				name, err = occam.RandomName()
 				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("index.html"))
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+				Expect(os.RemoveAll(source)).To(Succeed())
+			})
+
+			it("builds an OCI image for a Vue npm app", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "vue_npm_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.NPMInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Executing build process",
+					"    Running 'npm run build'",
+					"      ",
+					MatchRegexp(`      > vue_app@\d+\.\d+\.\d+ build`),
+					"      > vue-cli-service build",
+				))
+				Expect(logs).To(ContainLines(
+					"       DONE  Build complete. The dist directory is ready to be deployed.",
+				))
+				Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
+
+				container, err = docker.Container.Run.
+					WithCommand("ls -al /workspace/dist/").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring("index.html"))
+			})
 		})
-	})
+	}
 }

--- a/integration/vue_yarn_app_test.go
+++ b/integration/vue_yarn_app_test.go
@@ -13,82 +13,76 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testVueYarnApp(t *testing.T, context spec.G, it spec.S) {
-	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-
-		pack   occam.Pack
-		docker occam.Docker
-	)
-
-	it.Before(func() {
-		pack = occam.NewPack()
-		docker = occam.NewDocker()
-	})
-
-	context("when building a Vue yarn app", func() {
+func testVueYarnApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
 		var (
-			image     occam.Image
-			container occam.Container
-
-			name   string
-			source string
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
 		)
 
-		it.Before(func() {
-			var err error
-			name, err = occam.RandomName()
-			Expect(err).NotTo(HaveOccurred())
-		})
+		context("when building a Vue yarn app", func() {
+			var (
+				image     occam.Image
+				container occam.Container
 
-		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			Expect(os.RemoveAll(source)).To(Succeed())
-		})
+				name   string
+				source string
+			)
 
-		it("builds an OCI image for a Vue yarn app", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "vue_yarn_app"))
-			Expect(err).NotTo(HaveOccurred())
-
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.NodeEngine.Online,
-					settings.Buildpacks.Yarn.Online,
-					settings.Buildpacks.YarnInstall.Online,
-					settings.Buildpacks.NodeRunScript.Online,
-				).
-				WithPullPolicy("never").
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
-
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
-				"  Executing build process",
-				"    Running 'yarn run build'",
-				MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
-				"      $ vue-cli-service build",
-			))
-			Expect(logs).To(ContainLines(
-				"       DONE  Build complete. The dist directory is ready to be deployed.",
-			))
-
-			Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
-
-			container, err = docker.Container.Run.
-				WithCommand("ls -al /workspace/dist/").
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
+			it.Before(func() {
+				var err error
+				name, err = occam.RandomName()
 				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("index.html"))
+			})
+
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+				Expect(os.RemoveAll(source)).To(Succeed())
+			})
+
+			it("builds an OCI image for a Vue yarn app", func() {
+				var err error
+				source, err = occam.Source(filepath.Join("testdata", "vue_yarn_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.NodeEngine.Online,
+						settings.Buildpacks.Yarn.Online,
+						settings.Buildpacks.YarnInstall.Online,
+						settings.Buildpacks.NodeRunScript.Online,
+					).
+					WithPullPolicy("never").
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+					"  Executing build process",
+					"    Running 'yarn run build'",
+					MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
+					"      $ vue-cli-service build",
+				))
+				Expect(logs).To(ContainLines(
+					"       DONE  Build complete. The dist directory is ready to be deployed.",
+				))
+
+				Expect(logs).To(ContainLines(MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`)))
+
+				container, err = docker.Container.Run.
+					WithCommand("ls -al /workspace/dist/").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring("index.html"))
+			})
 		})
-	})
+	}
 }

--- a/run/main.go
+++ b/run/main.go
@@ -11,11 +11,7 @@ import (
 )
 
 func main() {
-	environment := noderunscript.Environment{
-		NodeRunScripts:  os.Getenv("BP_NODE_RUN_SCRIPTS"),
-		NodeProjectPath: os.Getenv("BP_NODE_PROJECT_PATH"),
-		LogLevel:        os.Getenv("BP_LOG_LEVEL"),
-	}
+	environment := noderunscript.LoadEnvironment(os.Environ())
 
 	packit.Run(
 		noderunscript.Detect(environment),

--- a/scripts.go
+++ b/scripts.go
@@ -9,14 +9,9 @@ import (
 )
 
 func ScriptsToRun(workingDir string, nodeRunScripts string) ([]string, string, error) {
-	scripts := []string{"build"}
-	manager := "npm"
-
-	if nodeRunScripts != "" {
-		scripts = strings.Split(nodeRunScripts, ",")
-		for i := range scripts {
-			scripts[i] = strings.TrimSpace(scripts[i])
-		}
+	scripts := strings.Split(nodeRunScripts, ",")
+	for i := range scripts {
+		scripts[i] = strings.TrimSpace(scripts[i])
 	}
 
 	file, err := os.Open(filepath.Join(workingDir, "package.json"))
@@ -43,6 +38,7 @@ func ScriptsToRun(workingDir string, nodeRunScripts string) ([]string, string, e
 		return nil, "", fmt.Errorf("could not find script(s) %s in package.json", missing)
 	}
 
+	manager := "npm"
 	_, err = os.Stat(filepath.Join(workingDir, "yarn.lock"))
 	if err == nil {
 		manager = "yarn"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Some users may still have a build script, but not want it to run during the build process. For these users, they can set `BP_NODE_RUN_SCRIPTS=""` to ensure the buildpack does not detect during their build.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
