### PR TITLE
Do not log error message during detection if the package.json is missing

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,8 @@
 package noderunscript
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -18,6 +20,10 @@ func Detect(env Environment) packit.DetectFunc {
 
 		_, packageManager, err := ScriptsToRun(filepath.Join(context.WorkingDir, env.NodeProjectPath), env.NodeRunScripts)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return packit.DetectResult{}, packit.Fail
+			}
+
 			return packit.DetectResult{}, err
 		}
 

--- a/detect.go
+++ b/detect.go
@@ -21,7 +21,7 @@ func Detect(env Environment) packit.DetectFunc {
 		_, packageManager, err := ScriptsToRun(filepath.Join(context.WorkingDir, env.NodeProjectPath), env.NodeRunScripts)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return packit.DetectResult{}, packit.Fail
+				return packit.DetectResult{}, packit.Fail.WithMessage("no package.json file present")
 			}
 
 			return packit.DetectResult{}, err

--- a/detect_test.go
+++ b/detect_test.go
@@ -174,7 +174,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					WorkingDir: workingDir,
 				})
 
-				Expect(err).To(MatchError(packit.Fail))
+				Expect(err).To(MatchError(packit.Fail.WithMessage("no package.json file present")))
 			})
 		})
 
@@ -207,7 +207,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					WorkingDir: workingDir,
 				})
 
-				Expect(err).To(MatchError(packit.Fail))
+				Expect(err).To(MatchError(packit.Fail.WithMessage("no package.json file present")))
 			})
 		})
 	})

--- a/detect_test.go
+++ b/detect_test.go
@@ -169,12 +169,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.Remove(filepath.Join(workingDir, "package.json"))).To(Succeed())
 			})
 
-			it("returns a failure", func() {
+			it("fails detection", func() {
 				_, err := detect(packit.DetectContext{
 					WorkingDir: workingDir,
 				})
 
-				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+				Expect(err).To(MatchError(packit.Fail))
 			})
 		})
 
@@ -202,12 +202,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
-			it("returns an error", func() {
+			it("fails detection", func() {
 				_, err := detect(packit.DetectContext{
 					WorkingDir: workingDir,
 				})
 
-				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+				Expect(err).To(MatchError(packit.Fail))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->
Fixes https://github.com/paketo-buildpacks/node-run-script/issues/180

## Use Cases
<!-- An explanation of the use cases your change enables -->

When running a build on a non-node.js application, `node-run-script` produces unnecessary error messages.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
