### PR TITLE
Make integration test log assertions more resilient.

### DIFF
--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -70,7 +70,8 @@ func testProjectPathApp(pack occam.Pack, docker occam.Docker) func(*testing.T, s
 					"      $ echo \"some commands\"",
 					"      some commands",
 					MatchRegexp(`    Done in \d+\.\d+s\.`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Running 'yarn run test_script_2'",
 					MatchRegexp(`      yarn run v\d+\.\d+\.\d+$`),
 					"      $ touch dummyfile.txt",

--- a/integration/simple_npm_app_test.go
+++ b/integration/simple_npm_app_test.go
@@ -71,13 +71,15 @@ func testSimpleNPMApp(pack occam.Pack, docker occam.Docker) func(*testing.T, spe
 					"      > echo \"some commands\"",
 					"      ",
 					"      some commands",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Running 'npm run test_script_2'",
 					"      ",
 					MatchRegexp(`      > simple_npm_app@\d+\.\d+\.\d+ test_script_2`),
 					"      > touch dummyfile.txt",
 					"      ",
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				))
 

--- a/integration/simple_yarn_app_test.go
+++ b/integration/simple_yarn_app_test.go
@@ -68,12 +68,14 @@ func testSimpleYarnApp(pack occam.Pack, docker occam.Docker) func(*testing.T, sp
 					"      $ echo \"some commands\"",
 					"      some commands",
 					MatchRegexp(`    Done in \d+\.\d+s\.`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					"    Running 'yarn run test_script_2'",
 					MatchRegexp(`      yarn run v\d+\.\d+\.\d+`),
 					"      $ touch dummyfile.txt",
 					MatchRegexp(`    Done in \d+\.\d+s\.`),
-					"",
+				))
+				Expect(logs).To(ContainLines(
 					MatchRegexp(`    Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				))
 


### PR DESCRIPTION
## Summary / Use Cases

This PR makes the integration test log assertions more resilient. Sometimes these tests fail because of extra lines not account for (e.g. npm update info). See e.g. https://github.com/paketo-buildpacks/node-run-script/issues/109#issuecomment-1476266774

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
